### PR TITLE
Add Wiki Entries to menu

### DIFF
--- a/includes/class-blicki-cpt.php
+++ b/includes/class-blicki-cpt.php
@@ -65,7 +65,7 @@ class Blicki_CPT {
                 'query_var'         => true,
                 'supports'          => array( 'title', 'editor', 'revisions' ),
                 'has_archive'       => _x( 'wiki', 'Blicki post type archive slug - resave permalinks after changing this', 'blicki' ),
-                'show_in_nav_menus' => false,
+                'show_in_nav_menus' => true,
                 'menu_icon'         => 'dashicons-carrot',
                 'show_in_rest'      => true,
             ) )


### PR DESCRIPTION
Adds Wiki Entries to WP-Admin and Customizer Menu

![screenshot_26-09-2016-15 07 31](https://cloud.githubusercontent.com/assets/150348/18853615/00676a6c-83fb-11e6-8ce6-1cb1dc117faa.jpg)
![screenshot_26-09-2016-15 06 55](https://cloud.githubusercontent.com/assets/150348/18853619/022a15ca-83fb-11e6-8dc0-7cc56a47c207.jpg)

Fixes #30 