### PR TITLE
Support Jetpack Markdown out of the box

### DIFF
--- a/includes/class-blicki-cpt.php
+++ b/includes/class-blicki-cpt.php
@@ -63,7 +63,7 @@ class Blicki_CPT {
                     'pages'      => false,
                 ),
                 'query_var'         => true,
-                'supports'          => array( 'title', 'editor', 'revisions' ),
+                'supports'          => array( 'title', 'editor', 'revisions', 'wpcom-markdown' ),
                 'has_archive'       => _x( 'wiki', 'Blicki post type archive slug - resave permalinks after changing this', 'blicki' ),
                 'show_in_nav_menus' => true,
                 'menu_icon'         => 'dashicons-carrot',


### PR DESCRIPTION
Currently it's possible to add Jetpack/WordPress.com markdown support by adding the following action in a theme or feature plugin:
```
add_action('init', 'blicki_markdown_init');
function blicki_markdown_init() {
    add_post_type_support( 'blicki', 'wpcom-markdown' );
} 
```

This PR allows it to be supported by default when Jetpack Markdown is on as per the documentation here:
https://jetpack.com/support/markdown/